### PR TITLE
Fix the alarm name for scale_down which was incorrectly named.

### DIFF
--- a/autoscaling_group.tf
+++ b/autoscaling_group.tf
@@ -9,7 +9,7 @@ resource "aws_autoscaling_policy" "scale_down_single" {
 resource "aws_cloudwatch_metric_alarm" "scale_down" {
   alarm_description   = "Monitors CPU utilization for ElasticSearch Cluster Nodes"
   alarm_actions       = ["${aws_autoscaling_policy.scale_down_single.arn}"]
-  alarm_name          = "elasticsearch-scale_up"
+  alarm_name          = "elasticsearch-scale_down"
   comparison_operator = "LessThanOrEqualToThreshold"
   namespace           = "AWS/EC2"
   metric_name         = "CPUUtilization"


### PR DESCRIPTION
https://app.shortcut.com/radarlabs/story/9610/modify-the-pelias-terraform-module-to-support-a-dynamic-scaling-policy-on-the-asg